### PR TITLE
Issue1fix

### DIFF
--- a/tasks/atomify.js
+++ b/tasks/atomify.js
@@ -10,8 +10,8 @@ module.exports = function(grunt) {
         var options = this.data;
         var done = this.async();
 
-        var cssConfig = options.cssConfig;
-        var jsConfig = options.jsConfig;
+        var cssConfig = options.css;
+        var jsConfig = options.js;
         var atomifyConfig = {};
         var expectedCallbacks = 0;
         var receivedCallbacks = 0;


### PR DESCRIPTION
This should address issue #1 in the Gruntfile configuration, and it also allows for multiple configuration targets for the atomify task.  This means that your atomify task name always needs the target suffix, even if you only have one target anyway (like this: `grunt atomify:dist`). I regret that this has no test coverage at this point, but I'm making a pull request now anyway, in the interest of time.

For example, in your Gruntfile.js:

``` javascript
atomify: {
  dist: {
    js: {
      entry: 'app/src/index.js',
      transforms: ['debowerify', 'uglifyify'],
      debug: false,
      output: 'dist/js/main.js'
    }
  },
  debug: {
    js: {
      entry: 'app/src/index.js',
      transforms: ['debowerify'],
      debug: true,
      output: 'debug/js/main.js'
    }
  }
}
```
