### PR TITLE
break the build if atomify returns an error

### DIFF
--- a/tasks/atomify.js
+++ b/tasks/atomify.js
@@ -59,6 +59,12 @@ module.exports = function(grunt) {
 
         if((cssConfig !== undefined) || (jsConfig !== undefined))  {
             atomify(atomifyConfig, function(error)  {
+                if (!!error) {
+                  var msg = 'Atomify error: ' + JSON.stringify(error);
+                  grunt.fail.warn(msg);
+                  done();
+                }
+
                 receivedCallbacks +=1;
                 if(receivedCallbacks === expectedCallbacks)  {
                     done();


### PR DESCRIPTION
This is a fix for issue #3.  It breaks the build if atomify sends an 'error' argument into the callback function, and it prints out the error in your build output.  It looks like the preferred way to bust a grunt build is with `grunt.fail.warn()`  (http://gruntjs.com/api/grunt.fail)  I regret that this fix has no test coverage, but I'm making a pull request anyway, in the interest of time.
