### PR TITLE
Fix error reporting code.

### DIFF
--- a/tasks/atomify.js
+++ b/tasks/atomify.js
@@ -42,8 +42,7 @@ module.exports = function(grunt) {
         if((cssConfig !== undefined) || (jsConfig !== undefined))  {
             atomify(atomifyConfig, function(error)  {
                 if (!!error) {
-                  var msg = 'Atomify error: ' + JSON.stringify(error) +
-                    ', src: ' + JSON.stringify(src) + ', type: ' + JSON.stringify(type);
+                  var msg = "Error processing file '" + error.filename + "': " + error.message;
                   grunt.fail.warn(msg);
                   done();
                 }


### PR DESCRIPTION
This PR: https://github.com/mich-cook/grunt-atomify/pull/9 broke error reporting code, because`src` and `type` aren't defined. So atomify error is just swallawed, we only see `src is not defined` instead. This is really misleading and frustrating.